### PR TITLE
Compatibility with TYPO3 11

### DIFF
--- a/Classes/Command/ExportRedirectCommand.php
+++ b/Classes/Command/ExportRedirectCommand.php
@@ -21,12 +21,11 @@ class ExportRedirectCommand extends Command
     protected $notificationHandler;
 
     public function __construct(
-        string $name = null,
         NotificationHandler $notificationHandler
     ) {
         $this->notificationHandler = $notificationHandler;
 
-        parent::__construct($name);
+        parent::__construct();
     }
 
     /**

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -42,7 +42,6 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
     protected $externalDomains = [];
 
     public function __construct(
-        string $name = null,
         NotificationHandler $notificationHandler,
         ExtensionConfiguration $extensionConfiguration
     ) {
@@ -51,7 +50,7 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
         $this->notificationHandler = $notificationHandler;
         $this->extensionConfiguration = $extensionConfiguration;
 
-        parent::__construct($name);
+        parent::__construct();
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each target entry will be matched by the routing configuration. If the target is
 
 ### Requirements
 
-* TYPO3 10
+* TYPO3 10 || 11
 * EXT:redirects
 
 ### Setup

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		}
 	},
 	"replace": {
-		"georgringer/redirect_generator": "*",
+		"georgringer/redirect-generator": "*",
 		"typo3-ter/redirect-generator": "self.version"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"typo3/cms-core": "^10.4",
-		"typo3/cms-redirects": "^10.4"
+		"typo3/cms-core": "^10.4 || ^11.5",
+		"typo3/cms-redirects": "^10.4 || ^11.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,8 +12,8 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' =>
         [
             'depends' => [
-                'typo3' => '10.4.0-10.4.99',
-                'redirects' => '^10.4.0-10.4.99',
+                'typo3' => '10.4.0-11.5.99',
+                'redirects' => '^10.4.0-11.5.99',
             ],
             'conflicts' => [],
             'suggests' => [],


### PR DESCRIPTION
The Command constructors mustn't expect the `$name` of the command. It is not used anyway (the name is defined in the `Services-yaml`) and TYPO3 11 cannot autowire the string.