### PR TITLE
Overwrite existing redirects

### DIFF
--- a/Classes/Command/AddRedirectCommand.php
+++ b/Classes/Command/AddRedirectCommand.php
@@ -37,6 +37,12 @@ class AddRedirectCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Define the status code, can be 301,302,303 or 307',
                 307
+            )->addOption(
+                'overwrite-existing',
+                null,
+                InputOption::VALUE_NONE,
+                'Overwrite existing source URL with the given target. Does not'
+                    . ' alter notification level (warning / info) of duplicate'
             )
             ->setHelp('Add a single redirect from the given source url to the target url. Target URL must be a valid page!');
     }
@@ -96,6 +102,10 @@ class AddRedirectCommand extends Command
     {
         $configuration = new Configuration();
 
+        $configuration->setOverwriteExisting(
+            $input->hasOption('overwrite-existing')
+            && $input->getOption('overwrite-existing') != false
+        );
 
         if ($input->hasOption('status-code') && !$configuration->statusCodeIsAllowed((int)$input->getOption('status-code'))) {
             throw new \RuntimeException('Status code wrong');

--- a/Classes/Command/AddRedirectCommand.php
+++ b/Classes/Command/AddRedirectCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace GeorgRinger\RedirectGenerator\Command;
 
 use GeorgRinger\RedirectGenerator\Domain\Model\Dto\Configuration;
+use GeorgRinger\RedirectGenerator\Exception\OverwrittenDuplicateException;
 use GeorgRinger\RedirectGenerator\Repository\RedirectRepository;
 use GeorgRinger\RedirectGenerator\Service\UrlMatcher;
 use Symfony\Component\Console\Command\Command;
@@ -41,9 +42,10 @@ class AddRedirectCommand extends Command
                 'overwrite-existing',
                 null,
                 InputOption::VALUE_NONE,
-                'Overwrite existing source URL with the given target. Does not'
-                    . ' alter notification level (warning / info) of duplicate'
-            )
+                'Overwrite existing source URL with the given target.'
+                . ' Uses notification level 2 (info) when actually overwriting'
+                . ' something'
+                )
             ->setHelp('Add a single redirect from the given source url to the target url. Target URL must be a valid page!');
     }
 
@@ -77,8 +79,13 @@ class AddRedirectCommand extends Command
                 $io->success('The following redirect would have been added:');
             } else {
                 $redirectRepository = GeneralUtility::makeInstance(RedirectRepository::class);
-                $redirectRepository->addRedirect($source, $result->getLinkString(), $configuration, $dryRun);
-                $io->success('Redirect has been added!');
+                $message = 'Redirect has been added!';
+                try {
+                    $redirectRepository->addRedirect($source, $result->getLinkString(), $configuration, $dryRun);
+                } catch (OverwrittenDuplicateException $exception) {
+                    $message = 'Redirect has been overwritten!';
+                }
+                $io->success($message);
             }
 
             $language = $result->getSiteRouteResult()->getLanguage();

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -41,6 +41,8 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
     /** @var array */
     protected $externalDomains = [];
 
+    protected bool $overwriteExisting = false;
+
     public function __construct(
         NotificationHandler $notificationHandler,
         ExtensionConfiguration $extensionConfiguration
@@ -75,6 +77,12 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
                 null,
                 InputOption::VALUE_NONE,
                 'Delete the import file after import'
+            )->addOption(
+                'overwrite-existing',
+                null,
+                InputOption::VALUE_NONE,
+                'Overwrite existing source URLs with the given target. Does not'
+                    . ' alter notification level (warning / info) of duplicates'
             )
             ->setHelp('Import a CSV file as redirects');
     }
@@ -92,6 +100,10 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
 
         $filePath = $input->getArgument('file');
         $dryRun = ($input->hasOption('dry-run') && $input->getOption('dry-run') != false);
+        $this->overwriteExisting = (
+            $input->hasOption('overwrite-existing')
+            && $input->getOption('overwrite-existing') != false
+        );
         if ($input->hasOption('external-domains')) {
             $this->setExternalDomains((string)$input->getOption('external-domains'));
         }
@@ -202,6 +214,7 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
                 }
 
                 $configuration = $this->getConfigurationFromItem($item);
+                $configuration->setOverwriteExisting($this->overwriteExisting);
                 if ($item['external'] ?? '' === '1' || $this->isExternalDomain($item['target'] ?? '')) {
                     $targetUrl = $item['target'];
                 } else {

--- a/Classes/Domain/Model/Dto/Configuration.php
+++ b/Classes/Domain/Model/Dto/Configuration.php
@@ -27,6 +27,8 @@ class Configuration
 
     private const ALLOWED_STATUS_CODES = [301, 302, 303, 307];
 
+    protected bool $overwriteExisting = false;
+
     /**
      * @return bool
      */
@@ -140,4 +142,14 @@ class Configuration
         return in_array($statusCode, self::ALLOWED_STATUS_CODES, true);
     }
 
+    public function getOverwriteExisting(): bool
+    {
+        return $this->overwriteExisting;
+    }
+
+    public function setOverwriteExisting(bool $overwriteExisting): self
+    {
+        $this->overwriteExisting = $overwriteExisting;
+        return $this;
+    }
 }

--- a/Classes/Exception/OverwrittenDuplicateException.php
+++ b/Classes/Exception/OverwrittenDuplicateException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeorgRinger\RedirectGenerator\Exception;
+
+use GeorgRinger\RedirectGenerator\Exception\DuplicateException;
+
+class OverwrittenDuplicateException extends DuplicateException
+{
+}

--- a/Classes/Repository/RedirectRepository.php
+++ b/Classes/Repository/RedirectRepository.php
@@ -54,11 +54,11 @@ class RedirectRepository
         $existingRow = $this->getRedirect($url);
         if (is_array($existingRow)) {
             if ($target !== $existingRow['target']) {
-                $this->updateExistingRow($existingRow, $target, $configuration, $dryRun);
-                $template = $configuration->getOverwriteExisting()
-                    ? 'Redirect for "%s" exists already with ID %s! Existing target was "%s", new target is now "%s".'
-                    : 'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".'
-                    ;
+                $template = 'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".';
+                if ($configuration->getOverwriteExisting()) {
+                    $this->updateExistingRow($existingRow, $target, $configuration, $dryRun);
+                    $template = 'Redirect for "%s" exists already with ID %s! Existing target was "%s", new target is now "%s".';
+                }
 
                 throw new ConflictingDuplicateException(
                     \sprintf(

--- a/Classes/Repository/RedirectRepository.php
+++ b/Classes/Repository/RedirectRepository.php
@@ -7,6 +7,7 @@ use GeorgRinger\RedirectGenerator\Domain\Model\Dto\Configuration;
 use GeorgRinger\RedirectGenerator\Domain\Model\Dto\UrlInfo;
 use GeorgRinger\RedirectGenerator\Exception\ConflictingDuplicateException;
 use GeorgRinger\RedirectGenerator\Exception\NonConflictingDuplicateException;
+use GeorgRinger\RedirectGenerator\Exception\OverwrittenDuplicateException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -47,22 +48,37 @@ class RedirectRepository
      * @param string $target
      * @param Configuration $configuration
      * @param bool $dryRun
-     * @throws ConflictingDuplicateException,NonConflictingDuplicateException
+     * @throws ConflictingDuplicateException,NonConflictingDuplicateException,OverwrittenDuplicateException
      */
     public function addRedirect(string $url, string $target, Configuration $configuration, bool $dryRun = false): void
     {
         $existingRow = $this->getRedirect($url);
         if (is_array($existingRow)) {
-            if ($target !== $existingRow['target']) {
-                $template = 'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".';
-                if ($configuration->getOverwriteExisting()) {
-                    $this->updateExistingRow($existingRow, $target, $configuration, $dryRun);
-                    $template = 'Redirect for "%s" exists already with ID %s! Existing target was "%s", new target is now "%s".';
-                }
+            if ($configuration->getOverwriteExisting()) {
+                $this->updateExistingRow($existingRow, $target, $configuration, $dryRun);
 
+                // This should be a return value, as this is normal control flow
+                // and nothing exceptional.
+                throw new OverwrittenDuplicateException(
+                    \sprintf(
+                        'Redirect for "%s" overwrites ID %s! Existing'
+                            . ' target was "%s", new target is now "%s".'
+                            ,
+                        $url,
+                        $existingRow['uid'],
+                        $existingRow['target'],
+                        $target
+                    ),
+                    1695904053
+                );
+            }
+
+            if ($target !== $existingRow['target']) {
                 throw new ConflictingDuplicateException(
                     \sprintf(
-                        $template,
+                        'Redirect for "%s" exists already with ID %s! Existing'
+                            . ' target is "%s", new target would be "%s".'
+                            ,
                         $url,
                         $existingRow['uid'],
                         $existingRow['target'],

--- a/Classes/Repository/RedirectRepository.php
+++ b/Classes/Repository/RedirectRepository.php
@@ -55,10 +55,14 @@ class RedirectRepository
         if (is_array($existingRow)) {
             if ($target !== $existingRow['target']) {
                 $this->updateExistingRow($existingRow, $target, $configuration, $dryRun);
+                $template = $configuration->getOverwriteExisting()
+                    ? 'Redirect for "%s" exists already with ID %s! Existing target was "%s", new target is now "%s".'
+                    : 'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".'
+                    ;
 
                 throw new ConflictingDuplicateException(
                     \sprintf(
-                        'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".',
+                        $template,
                         $url,
                         $existingRow['uid'],
                         $existingRow['target'],

--- a/Classes/Repository/RedirectRepository.php
+++ b/Classes/Repository/RedirectRepository.php
@@ -150,7 +150,7 @@ class RedirectRepository
         $connection->update(self::TABLE, $data, ['uid' => $existingRow['uid']]);
     }
 
-    protected function getExecTime(): string
+    protected function getExecTime(): int
     {
         return $GLOBALS['EXEC_TIME'];
     }

--- a/Classes/Utility/NotificationHandler.php
+++ b/Classes/Utility/NotificationHandler.php
@@ -16,6 +16,7 @@ class NotificationHandler
     public const IMPORT_SKIPPED_MESSAGE = '%s redirects skipped because source is same as target!';
     public const IMPORT_DUPLICATES_CONFLICTING_MESSAGE = '%s redirects skipped because of conflicting duplicates!';
     public const IMPORT_DUPLICATES_NON_CONFLICTING_MESSAGE = '%s redirects skipped because of non conflicting duplicates.';
+    public const IMPORT_DUPLICATES_OVERWRITTEN_MESSAGE = '%s redirects overwritten because of duplicates.';
 
     /** @var ExtensionConfiguration|null */
     protected $extensionConfiguration = null;
@@ -100,6 +101,12 @@ class NotificationHandler
             $lines[] = \sprintf(
                 '[Info] ' . self::IMPORT_DUPLICATES_NON_CONFLICTING_MESSAGE,
                 \count($data['duplicates']['non_conflicting'])
+            );
+        }
+        if (!empty($data['duplicates']['overwritten']) && $level >= 2) {
+            $lines[] = \sprintf(
+                '[Info] ' . self::IMPORT_DUPLICATES_OVERWRITTEN_MESSAGE,
+                \count($data['duplicates']['overwritten'])
             );
         }
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following options are available:
 * `--status-code`: Define the status code, allowed are *301*,*302*, *303* and *307*.
 * `--dry-run`: If set, the redirect won't be added
 * `--overwrite existing`: Overwrite existing source URLs with the given target.
-  Does not alter notification level (warning / info) of duplicates
+  Uses notification level 2 (info) when actually overwriting something
 
 ### Import CSV
 
@@ -74,7 +74,7 @@ The following options are available:
 * `--external-domains`: Provide a comma separated list of domains which are external
 * `--delete-file`: If set the CSV file is deleted after (a successful or unsuccessful) import
 * `--overwrite existing`: Overwrite existing source URLs with the given target.
-  Does not alter notification level (warning / info) of duplicates
+  Uses notification level 2 (info) when actually overwriting something
 
 > This command can be run in the scheduler (select *Execute console commands* as class)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The following options are available:
 
 * `--status-code`: Define the status code, allowed are *301*,*302*, *303* and *307*.
 * `--dry-run`: If set, the redirect won't be added
+* `--overwrite existing`: Overwrite existing source URLs with the given target.
+  Does not alter notification level (warning / info) of duplicates
 
 ### Import CSV
 
@@ -55,12 +57,12 @@ Use the following CLI command:
 ./bin/typo3 redirect:import <path-to-file.csv>
 ```
 
-````csv
+```csv
 source;target;status_code
 /fo/bar;http://t3-master.vm/examples/extensions/news;301
 /fo/bar2;http://t3-master.vm/examples/extensions/news;307
 /fo/bar3;http://t3-master.vm/exakqwkqkwmples/extensions/news;301
-````
+```
 
 A sample CSV file can be found at `EXT:redirect_generator/Resources/Private/Examples/ImportBasic.csv`
 
@@ -71,6 +73,8 @@ The following options are available:
 * `--dry-run`: If set, the redirect won't be added
 * `--external-domains`: Provide a comma separated list of domains which are external
 * `--delete-file`: If set the CSV file is deleted after (a successful or unsuccessful) import
+* `--overwrite existing`: Overwrite existing source URLs with the given target.
+  Does not alter notification level (warning / info) of duplicates
 
 > This command can be run in the scheduler (select *Execute console commands* as class)
 


### PR DESCRIPTION
* New option for `import` command, that allows overwriting existing redirects
* If set, overwriting shall not cause errors, warnings or eMail notifications
* Successful log entries are required when actually overwriting redirects